### PR TITLE
Remove --no-lock flag from brew bundle command

### DIFF
--- a/home/.chezmoiscripts/00-run-before/run_before_02-install-packages-from-brewfile.sh.tmpl
+++ b/home/.chezmoiscripts/00-run-before/run_before_02-install-packages-from-brewfile.sh.tmpl
@@ -28,6 +28,6 @@ if [[ ! -f "$BREWFILE" ]]; then
 fi
 
 echo "Installing packages from Brewfile..."
-brew bundle --file="$BREWFILE" --no-lock
+brew bundle --file="$BREWFILE"
 
 echo "Packages installed successfully!"


### PR DESCRIPTION
## Summary
Updated the Brewfile installation script to remove the `--no-lock` flag from the `brew bundle` command, allowing Homebrew to generate and maintain a lock file during package installation.

## Changes
- Removed `--no-lock` flag from `brew bundle` invocation in the package installation script
- This allows `brew bundle` to create and update `Brewfile.lock.json` for reproducible installations

## Details
The `--no-lock` flag was preventing Homebrew from generating a lock file that tracks exact package versions and dependencies. By removing this flag, the script now enables:
- Reproducible package installations across different machines
- Better dependency tracking and version pinning
- Easier rollback to known-good package states

This change aligns with Homebrew best practices for managing package dependencies in automated environments.

https://claude.ai/code/session_01B7xR9bvk9JU5whrzkVXMWh