### PR TITLE
Remove deprecated Homebrew taps from Brewfile

### DIFF
--- a/home/Brewfile
+++ b/home/Brewfile
@@ -2,8 +2,6 @@
 # Run: brew bundle --file=~/Brewfile
 
 # Taps
-tap "homebrew/bundle"
-tap "homebrew/cask-fonts"
 
 # === Shells ===
 brew "bash"           # Bash 5.x (newer than macOS default)


### PR DESCRIPTION
## Summary
Removed two deprecated Homebrew taps from the Brewfile that are no longer necessary.

## Changes
- Removed `tap "homebrew/bundle"` - This tap is no longer needed as bundle functionality is now built into Homebrew core
- Removed `tap "homebrew/cask-fonts"` - This tap has been deprecated; font casks are now available through the main cask repository

## Details
These taps were historically required but have been integrated into Homebrew's main repositories. Removing them simplifies the Brewfile configuration and aligns with current Homebrew best practices.

https://claude.ai/code/session_012VpbjRyqZcqK4tMyZWceEd