### PR TITLE
Improve Homebrew detection and installation robustness

### DIFF
--- a/home/bin/executable_bootstrap-chezmoi.sh
+++ b/home/bin/executable_bootstrap-chezmoi.sh
@@ -8,13 +8,30 @@
 # - 1Password app (macOS) - required for SSH agent to access private repo
 # - 1Password CLI
 
-set -e
-
 echo "==> Chezmoi Bootstrap Script"
 echo "    Installing prerequisites..."
 echo ""
 
 OS="$(uname -s)"
+
+# Detect brew from known paths (it may not be in PATH yet)
+_find_brew() {
+  if command -v brew &> /dev/null; then
+    return 0
+  fi
+  local brew_paths=(
+    /opt/homebrew/bin/brew
+    /usr/local/bin/brew
+    /home/linuxbrew/.linuxbrew/bin/brew
+  )
+  for p in "${brew_paths[@]}"; do
+    if [[ -x "$p" ]]; then
+      eval "$("$p" shellenv)"
+      return 0
+    fi
+  done
+  return 1
+}
 
 # --- Xcode CLI Tools (macOS only) ---
 if [[ "$OS" == "Darwin" ]]; then
@@ -33,20 +50,16 @@ if [[ "$OS" == "Darwin" ]]; then
 fi
 
 # --- Homebrew ---
-if ! command -v brew &> /dev/null; then
+if ! _find_brew; then
   echo "==> Installing Homebrew..."
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || true
+  # Re-detect brew after install
+  if ! _find_brew; then
+    echo "!! Homebrew installation failed. Please install manually and re-run."
+    exit 1
+  fi
 else
   echo "==> Homebrew: already installed"
-fi
-
-# Add brew to current session PATH
-if [[ -f "/opt/homebrew/bin/brew" ]]; then
-  eval "$(/opt/homebrew/bin/brew shellenv)"
-elif [[ -f "/usr/local/bin/brew" ]]; then
-  eval "$(/usr/local/bin/brew shellenv)"
-elif [[ -f "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
-  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
 
 # --- macOS: 1Password App (for SSH agent) ---


### PR DESCRIPTION
## Summary
Refactored the Homebrew detection and initialization logic to be more robust and handle edge cases where Homebrew may not be in the PATH immediately after installation.

## Key Changes
- Removed `set -e` to allow better error handling and recovery
- Created `_find_brew()` helper function that:
  - Checks if brew is already in PATH
  - Falls back to checking known installation paths on macOS and Linux
  - Automatically sets up the shell environment when found
- Updated Homebrew installation to:
  - Use `|| true` to allow the script to continue even if installation fails
  - Re-detect Homebrew after installation attempt
  - Provide clear error messaging if installation fails
- Consolidated brew PATH setup into the `_find_brew()` function, eliminating duplicate logic

## Implementation Details
The new `_find_brew()` function checks multiple known Homebrew installation paths:
- `/opt/homebrew/bin/brew` (Apple Silicon Macs)
- `/usr/local/bin/brew` (Intel Macs and older installations)
- `/home/linuxbrew/.linuxbrew/bin/brew` (Linux)

This approach ensures the script can locate and initialize Homebrew even if it's not yet in the user's PATH, which commonly occurs on fresh installations or when using non-standard shells.

https://claude.ai/code/session_015NYQ7jArkcYyY5CaxVjC6d