### PR TITLE
Fix 1Password CLI installation for Linux systems

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -124,8 +124,12 @@ sudo apt update && sudo apt install -y build-essential curl wget git fish
 NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 
-# Install 1Password CLI
-brew install 1password-cli
+# Install 1Password CLI (Debian/Ubuntu)
+curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
+  sudo gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main" | \
+  sudo tee /etc/apt/sources.list.d/1password.list
+sudo apt update && sudo apt install -y 1password-cli
 
 # Install Chezmoi
 sh -c "$(curl -fsLS chezmoi.io/get)"
@@ -418,8 +422,8 @@ After installation, verify everything works:
 
 **Solution:**
 ```bash
-# Install 1Password CLI
-brew install 1password-cli
+# macOS: Install 1Password CLI
+brew install --cask 1password-cli
 
 # Or download from
 # https://1password.com/downloads/command-line/

--- a/home/Brewfile
+++ b/home/Brewfile
@@ -91,7 +91,6 @@ brew "gnupg"          # GPG
 brew "sshpass"        # SSH password auth
 brew "pinentry"       # GPG PIN entry
 brew "pinentry-mac"   # macOS PIN entry
-brew "1password-cli"  # 1Password CLI
 
 # === Utilities ===
 brew "chezmoi"        # Dotfiles manager
@@ -107,6 +106,7 @@ brew "dockutil"       # Dock management
 
 # Security & Privacy
 cask "1password"                   # Password manager
+cask "1password-cli"               # 1Password CLI
 cask "gpg-suite-no-mail"           # GPG tools without Mail plugin
 cask "proton-pass"                 # Proton password manager
 cask "protonvpn"                   # Proton VPN client

--- a/home/bin/executable_bootstrap-chezmoi.sh
+++ b/home/bin/executable_bootstrap-chezmoi.sh
@@ -78,7 +78,22 @@ if ! command -v op &> /dev/null; then
   if [[ "$OS" == "Darwin" ]]; then
     brew install --cask 1password-cli
   else
-    brew install 1password-cli
+    # Linux: install from 1Password's official package repository
+    if command -v apt-get &> /dev/null; then
+      curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
+        sudo gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main" | \
+        sudo tee /etc/apt/sources.list.d/1password.list
+      sudo apt-get update && sudo apt-get install -y 1password-cli
+    elif command -v dnf &> /dev/null; then
+      sudo rpm --import https://downloads.1password.com/linux/keys/1password.asc
+      sudo sh -c 'echo -e "[1password]\nname=1Password\nbaseurl=https://downloads.1password.com/linux/rpm/stable/\$basearch\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://downloads.1password.com/linux/keys/1password.asc" > /etc/yum.repos.d/1password.repo'
+      sudo dnf install -y 1password-cli
+    else
+      echo "!! Unsupported package manager. Please install 1Password CLI manually:"
+      echo "   https://developer.1password.com/docs/cli/get-started/"
+      exit 1
+    fi
   fi
 else
   echo "==> 1Password CLI: already installed"


### PR DESCRIPTION
## Summary
Updates 1Password CLI installation to use official package repositories on Linux instead of Homebrew, which provides better compatibility and official support. Also reorganizes Brewfile to correctly categorize 1Password CLI as a cask on macOS.

## Changes
- **Deployment Guide**: Replaced `brew install 1password-cli` with official 1Password Debian repository setup for Linux systems
- **Brewfile**: Moved `1password-cli` from brew formula to cask section (macOS only), aligning with how it's actually distributed on macOS
- **Bootstrap Script**: Enhanced Linux installation logic to:
  - Support Debian/Ubuntu systems via official APT repository
  - Support Fedora/RHEL systems via official DNF repository
  - Provide helpful error message for unsupported package managers
  - Keep macOS installation via Homebrew cask

## Implementation Details
- Linux installations now add 1Password's GPG key and official repository before installing
- Separate code paths for apt-based and dnf-based systems with appropriate package manager commands
- Maintains backward compatibility with macOS installation via `brew install --cask`
- Improves reliability by using official sources instead of third-party Homebrew formulas

https://claude.ai/code/session_01PPAwZHgU4AWmDX2TEB2FpZ