### PR TITLE
Improve Brewfile installation by keeping sudo session alive

### DIFF
--- a/home/.chezmoiscripts/00-run-before/run_before_02-install-packages-from-brewfile.sh.tmpl
+++ b/home/.chezmoiscripts/00-run-before/run_before_02-install-packages-from-brewfile.sh.tmpl
@@ -28,6 +28,16 @@ if [[ ! -f "$BREWFILE" ]]; then
 fi
 
 echo "Installing packages from Brewfile..."
+
+# Ask for sudo password once upfront and keep the session alive
+# so cask installs don't repeatedly prompt
+if sudo --validate 2>/dev/null; then
+  # Refresh sudo timestamp in the background until this script exits
+  while true; do sudo --non-interactive --validate; sleep 30; done &
+  SUDO_REFRESH_PID=$!
+  trap 'kill "$SUDO_REFRESH_PID" 2>/dev/null' EXIT
+fi
+
 brew bundle --file="$BREWFILE"
 
 echo "Packages installed successfully!"


### PR DESCRIPTION
## Summary
This change improves the package installation experience by maintaining an active sudo session throughout the Brewfile installation process, eliminating repeated password prompts for cask installations.

## Key Changes
- Added upfront sudo validation before running `brew bundle`
- Implemented a background process that refreshes the sudo timestamp every 30 seconds
- Added proper cleanup with a trap handler to kill the refresh process when the script exits

## Implementation Details
The solution validates sudo access once at the beginning of the installation. If successful, a background loop continuously refreshes the sudo session timestamp every 30 seconds, keeping the user authenticated throughout the entire Brewfile installation. This is particularly beneficial for cask installations which often require elevated privileges and would otherwise prompt for the password multiple times.

The background process PID is captured and cleaned up via an EXIT trap to ensure proper resource cleanup when the script completes or is interrupted.

https://claude.ai/code/session_01J3VQLfki8pZQ9zHwhVz6bx