### PR TITLE
Suppress Spotlight configuration errors on macOS setup

### DIFF
--- a/home/bin/macos/executable_setup-macos-defaults
+++ b/home/bin/macos/executable_setup-macos-defaults
@@ -235,7 +235,7 @@ defaults write com.apple.mail SpellCheckingBehavior -string "NoSpellCheckingEnab
 # Spotlight
 # =============================================================================
 
-sudo defaults write /.Spotlight-V100/VolumeConfiguration Exclusions -array "/Volumes"
+sudo defaults write /.Spotlight-V100/VolumeConfiguration Exclusions -array "/Volumes" 2>/dev/null || true
 defaults write com.apple.spotlight orderedItems -array \
   '{"enabled" = 1;"name" = "APPLICATIONS";}' \
   '{"enabled" = 1;"name" = "SYSTEM_PREFS";}' \


### PR DESCRIPTION
## Summary
Modified the Spotlight configuration command in the macOS setup script to gracefully handle errors that may occur when writing to the Spotlight volume configuration.

## Changes
- Added error suppression (`2>/dev/null`) and fallback (`|| true`) to the Spotlight exclusions defaults write command
- This prevents the setup script from failing if the Spotlight configuration path is inaccessible or doesn't exist on certain macOS versions or configurations

## Details
The Spotlight volume configuration path (`/.Spotlight-V100/VolumeConfiguration`) may not be accessible or present on all macOS systems. By redirecting stderr to `/dev/null` and using `|| true`, the script will continue execution even if this command fails, making the setup process more robust across different macOS environments.

https://claude.ai/code/session_01LTeouT5uRtZ78T4NDsiUgL