### PR TITLE
feat(scripts): add status messages to all chezmoi scripts

### DIFF
--- a/home/.chezmoiscripts/00-run-before/run_before_00_configure_1password.sh
+++ b/home/.chezmoiscripts/00-run-before/run_before_00_configure_1password.sh
@@ -26,6 +26,8 @@ if command -v op >/dev/null 2>&1; then
     op account add --address "my.1password.com" --email "$email" --secret-key "$secret_key"
 
     echo "1Password account added successfully."
+  else
+    echo "1Password account already configured."
   fi
 else
   echo "1Password CLI (op) is not installed or not in PATH."

--- a/home/.chezmoiscripts/01-common/run_after_00-local-files.sh.tmpl
+++ b/home/.chezmoiscripts/01-common/run_after_00-local-files.sh.tmpl
@@ -10,10 +10,13 @@ echo " Create Local Configuration Files"
 echo "-----------------------------------------------------------------------"
 echo ""
 
+CREATED=0
+
 # Create main configuration files if they do not exist
 if [ ! -f ~/.config/git/config ]; then
   echo "Creating ~/.config/git/config"
   cp ~/.config/etc/gitconfig.template ~/.config/git/config
+  CREATED=1
 fi
 
 # SSH config section
@@ -21,12 +24,14 @@ if [ ! -d ~/.ssh ]; then
   echo "Creating ~/.ssh directory"
   mkdir -p ~/.ssh
   chmod 700 ~/.ssh
+  CREATED=1
 fi
 
 if [ ! -f ~/.ssh/config ]; then
   echo "Creating ~/.ssh/config"
   cp ~/.config/etc/ssh_config.template ~/.ssh/config
   chmod 600 ~/.ssh/config
+  CREATED=1
 fi
 
 # GnuPG section
@@ -34,34 +39,40 @@ if [ ! -d ~/.gnupg ]; then
   echo "Creating ~/.gnupg directory"
   mkdir -p ~/.gnupg
   chmod 700 ~/.gnupg
+  CREATED=1
 fi
 
 if [ ! -f ~/.gnupg/gpg-agent.conf ]; then
   echo "Creating ~/.gnupg/gpg-agent.conf"
   cp ~/.config/etc/gpg-agent.conf.template ~/.gnupg/gpg-agent.conf
   chmod 600 ~/.gnupg/gpg-agent.conf
+  CREATED=1
 fi
 
 if [ ! -f ~/.npmrc ]; then
   if [ -f ~/.config/etc/npmrc.template ]; then
     echo "Creating ~/.npmrc from template"
     cp ~/.config/etc/npmrc.template ~/.npmrc
+    CREATED=1
   fi
 fi
 
 if [ ! -f ~/.config/fish/config_local.fish ]; then
   echo "Creating ~/.config/fish/config_local.fish"
   cp ~/.config/fish/config_local.template.fish ~/.config/fish/config_local.fish
+  CREATED=1
 fi
 
 if [ ! -f ~/.config/bash/bashrc_local ]; then
   echo "Creating ~/.config/bash/bashrc_local"
   cp ~/.config/bash/bashrc_local.template ~/.config/bash/bashrc_local
+  CREATED=1
 fi
 
 if [ ! -f ~/.config/zsh/zshrc_local ]; then
   echo "Creating ~/.config/zsh/zshrc_local"
   cp ~/.config/zsh/zshrc_local.template ~/.config/zsh/zshrc_local
+  CREATED=1
 fi
 
 {{- if eq .chezmoi.os "darwin" }}
@@ -69,5 +80,10 @@ if [ ! -f /Library/LaunchDaemons/limit.maxfiles.plist ]; then
   echo "Creating /Library/LaunchDaemons/limit.maxfiles.plist"
   sudo cp ~/.config/etc/limit.maxfiles.plist /Library/LaunchDaemons/limit.maxfiles.plist
   sudo chmod 644 /Library/LaunchDaemons/limit.maxfiles.plist
+  CREATED=1
 fi
 {{- end }}
+
+if [ "$CREATED" -eq 0 ]; then
+  echo "All local configuration files already exist."
+fi

--- a/home/.chezmoiscripts/01-common/run_once_after_00-darwin-system-defaults.sh.tmpl
+++ b/home/.chezmoiscripts/01-common/run_once_after_00-darwin-system-defaults.sh.tmpl
@@ -46,4 +46,8 @@ if command -v dockutil &> /dev/null; then
 
   # Restart Dock for dockutil changes
   killall Dock 2>/dev/null || true
+else
+  echo "dockutil not found, skipping Dock configuration"
 fi
+
+echo "macOS system defaults applied."

--- a/home/.chezmoiscripts/01-common/run_once_after_01-mise-install.sh.tmpl
+++ b/home/.chezmoiscripts/01-common/run_once_after_01-mise-install.sh.tmpl
@@ -13,6 +13,7 @@ echo ""
 {{ template "brew-shellenv" . }}
 
 if command -v mise >/dev/null 2>&1; then
+  echo "Installing mise tools and generating completions..."
   mise use -g usage
   mise completion fish >~/.config/fish/completions/mise.fish
 
@@ -33,4 +34,6 @@ if command -v mise >/dev/null 2>&1; then
       sleep 2  # Add a small delay between attempts
     fi
   done
+else
+  echo "mise not found, skipping tool installation."
 fi

--- a/home/.chezmoiscripts/01-common/run_once_after_02-install-fisher.fish.tmpl
+++ b/home/.chezmoiscripts/01-common/run_once_after_02-install-fisher.fish.tmpl
@@ -19,7 +19,10 @@ fi
 
 fish -c '
 if not type --quiet fisher
+    echo "Installing Fisher and plugins..."
     curl -fsL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source
     fisher update
+else
+    echo "Fisher already installed."
 end
 '

--- a/home/.chezmoiscripts/01-common/run_once_after_02.1-some-fish-setup.fish.tmpl
+++ b/home/.chezmoiscripts/01-common/run_once_after_02.1-some-fish-setup.fish.tmpl
@@ -18,4 +18,6 @@ if ! command -v fish >/dev/null 2>&1; then
 fi
 
 # Clear fish welcome message
+echo "Clearing fish welcome message..."
 fish -c 'set -U fish_greeting ""'
+echo "Fish shell setup complete."

--- a/home/.chezmoiscripts/01-common/run_once_after_05-nvim_lazy-install.sh.tmpl
+++ b/home/.chezmoiscripts/01-common/run_once_after_05-nvim_lazy-install.sh.tmpl
@@ -13,6 +13,9 @@ echo ""
 NVIM_DIR="${HOME}/.config/nvim"
 
 if [ ! -d "${NVIM_DIR}" ]; then
-  echo "Installing nvim_lazy"
+  echo "Cloning nvim_lazy..."
   git clone https://github.com/schmas/nvim_lazy.git "${NVIM_DIR}"
+  echo "nvim_lazy installed successfully."
+else
+  echo "nvim_lazy already installed at ${NVIM_DIR}."
 fi


### PR DESCRIPTION
Every script now provides feedback for both active and skip/already-done paths, so the banner is never followed by silence:
- 1Password: "already configured" when account exists
- Local files: "All local configuration files already exist" when nothing to create
- macOS defaults: "applied" confirmation and dockutil skip message
- mise: "not found, skipping" when mise is absent
- Fisher: "already installed" when present
- Fish setup: progress and completion messages
- nvim_lazy: "already installed" when dir exists

https://claude.ai/code/session_01TzmdfT9Lfmm48Hj7DThvcD