### PR TITLE
Increase HTTP timeout in mise configuration to 120 seconds

### DIFF
--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -22,3 +22,4 @@ go = "latest"
 
 [settings]
 experimental = true
+http_timeout = 120


### PR DESCRIPTION
## Summary
Updated the mise configuration to increase the HTTP timeout setting from its default value to 120 seconds.

## Changes
- Added `http_timeout = 120` to the `[settings]` section in `~/.config/mise/config.toml`

## Details
This change extends the HTTP timeout duration to 120 seconds, which may help prevent timeout errors when downloading or fetching remote resources (such as tool versions) over slower network connections or from slower servers.

https://claude.ai/code/session_019n8rjn6DugcdMeMNErxyC1